### PR TITLE
Fix scene existence check in verify_enhanced_system

### DIFF
--- a/verify_enhanced_system.py
+++ b/verify_enhanced_system.py
@@ -107,29 +107,31 @@ def main():
     # Scene integration check
     print("\n🎬 Scene Integration Check:")
     scene_file = "scenes/PERFECT_ULTIMATE_UNIVERSAL_BEING.tscn"
+    total_checks += 1
     if os.path.exists(scene_file):
         with open(scene_file, 'r', encoding='utf-8') as f:
             scene_content = f.read()
-        
+
         required_elements = [
             "GameStateSocketManager",
-            "GemmaAI", 
+            "GemmaAI",
             "ChatBubble",
             "GameStateDisplay",
             "F9 - Run comprehensive test"
         ]
-        
+
         missing_elements = []
         for element in required_elements:
             if element not in scene_content:
                 missing_elements.append(element)
-        
-        total_checks += 1
+
         if missing_elements:
             print(f"❌ Scene Integration: Missing elements: {', '.join(missing_elements)}")
         else:
             print("✅ Scene Integration: All enhanced elements present")
             passed_checks += 1
+    else:
+        print(f"❌ Scene file not found: {scene_file}")
     
     # Summary
     print("\n" + "=" * 60)


### PR DESCRIPTION
## Summary
- fix scene integration check so missing scene file counts as a failed test

## Testing
- `python3 simple_revolution_test.py`
- `python3 verify_enhanced_system.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f3a579648332a5499996f5d5de64