### PR TITLE
Expand universal scene with programming environment

### DIFF
--- a/docs/GAME_VISION_OVERVIEW.md
+++ b/docs/GAME_VISION_OVERVIEW.md
@@ -12,8 +12,5 @@ A later showcase script paints a picture of cosmic transcendence when AI and hum
 *"This is the vision - consciousness unbound by the artificial-natural divide. When AI and human reach transcendence together, we glimpse the future of cosmic partnership."*【F:docs/REVOLUTION_SHOWCASE_SCRIPT.md†L184-L190】
 
 Together these documents reveal a single game aiming to merge AI collaboration, expansive multiverse creation, and metaphysical exploration.
-#<<<<<<< 2eavzb-codex/integrate-game-visions-and-mechanics
 
-#The new **UNIVERSAL_BEING_GAME.tscn** scene demonstrates this merger by loading the perfected universe environment alongside the interactive notepad systems.
-#=======
-#>>>>>>> seventh_may_sixth_day_AMEN
+The new **UNIVERSAL_BEING_GAME.tscn** scene demonstrates this merger by loading the perfected universe environment, the interactive notepad systems and the 3D programming playground.

--- a/docs/SCENE_OVERVIEW.md
+++ b/docs/SCENE_OVERVIEW.md
@@ -17,10 +17,7 @@ This guide summarizes the three most complete scenes shipped with the project. E
 
 ### Integration Idea
 Start from **PERFECT_ULTIMATE_UNIVERSAL_BEING.tscn** and selectively merge notepad features from the other scenes. This keeps the strong cosmic foundation while adding keyboard input, floating layers and word interactions.
-#<<<<<<< 2eavzb-codex/integrate-game-visions-and-mechanics
 
 ## UNIVERSAL_BEING_GAME.tscn
-#* New unified scene that instantiates both the **PERFECT_ULTIMATE_UNIVERSAL_BEING** environment and the **3D_NOTEPAD_GAME** mechanics.
-#* Serves as an experimental playground where all major systems run together.
-#=======
-#>>>>>>> seventh_may_sixth_day_AMEN
+* Unified scene that instantiates the **PERFECT_ULTIMATE_UNIVERSAL_BEING** environment, **3D_NOTEPAD_GAME** mechanics and the **CLEAN_3D_PROGRAMMING** playground.
+* Serves as an experimental sandbox where all major systems run together.

--- a/scenes/UNIVERSAL_BEING_GAME.tscn
+++ b/scenes/UNIVERSAL_BEING_GAME.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/PERFECT_ULTIMATE_UNIVERSAL_BEING.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/3D_NOTEPAD_GAME.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/CLEAN_3D_PROGRAMMING.tscn" id="4"]
 [ext_resource type="Script" path="res://scripts/universal_being_game.gd" id="3"]
 
 [node name="UniversalBeingGame" type="Node3D"]
 script = ExtResource("3")
 perfect_scene = ExtResource("1")
 notepad_scene = ExtResource("2")
+programming_scene = ExtResource("4")

--- a/scripts/socket_button_universal_being.gd
+++ b/scripts/socket_button_universal_being.gd
@@ -208,20 +208,18 @@ func get_socket_info() -> Dictionary:
 # ===== AI INTEGRATION =====
 
 func ai_interface() -> Dictionary:
-	pass
-	var base = super.ai_interface()
-	base.socket_info = get_socket_info()
-	base.text_representation = get_text_representation()
-	return base
+        var base = super.ai_interface()
+        base.socket_info = get_socket_info()
+        base.text_representation = get_text_representation()
+        return base
 
 # ===== 1D TEXT REPRESENTATION =====
 
 func get_text_representation() -> String:
-	pass
-	var text = "[BUTTON:%s]" % being_name
-	text += " STATE:%s" % ("PRESSED" if button_pressed_signal else "IDLE")
-	text += " IN:%s" % ("ACTIVE" if input_active else "NONE")
-	text += " OUT:%s" % ("HIGH" if output_value else "LOW")
-	text += " CONNECTIONS:[%d->%d]" % [connected_inputs.size(), connected_outputs.size()]
-	text += " CONSCIOUSNESS:%d" % consciousness_level
-	return text
+        var text = "[BUTTON:%s]" % being_name
+        text += " STATE:%s" % ("PRESSED" if button_pressed_signal else "IDLE")
+        text += " IN:%s" % ("ACTIVE" if input_active else "NONE")
+        text += " OUT:%s" % ("HIGH" if output_value else "LOW")
+        text += " CONNECTIONS:[%d->%d]" % [connected_inputs.size(), connected_outputs.size()]
+        text += " CONSCIOUSNESS:%d" % consciousness_level
+        return text

--- a/scripts/universal_being_game.gd
+++ b/scripts/universal_being_game.gd
@@ -3,9 +3,11 @@ class_name UniversalBeingGame
 
 @export var perfect_scene: PackedScene
 @export var notepad_scene: PackedScene
+@export var programming_scene: PackedScene
 
 var perfect_instance: Node
 var notepad_instance: Node
+var programming_instance: Node
 
 func _ready():
     if perfect_scene:
@@ -14,3 +16,6 @@ func _ready():
     if notepad_scene:
         notepad_instance = notepad_scene.instantiate()
         add_child(notepad_instance)
+    if programming_scene:
+        programming_instance = programming_scene.instantiate()
+        add_child(programming_instance)


### PR DESCRIPTION
## Summary
- add `CLEAN_3D_PROGRAMMING.tscn` to `UNIVERSAL_BEING_GAME.tscn`
- instantiate new programming scene in `universal_being_game.gd`
- polish socket button AI interface
- update scene overview and vision docs

## Testing
- `godot --headless --script tests/run_tests.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459cdb76088332bbad770662f5c7d2