### PR TITLE
Add dumb calculator command to universal console

### DIFF
--- a/scripts/dream_calculator.gd
+++ b/scripts/dream_calculator.gd
@@ -1,0 +1,57 @@
+extends RefCounted
+class_name DreamCalculator
+
+const COMMAND_MULTIPLY: String = "mul"
+const COMMAND_DIVIDE: String = "div"
+
+func evaluate(raw_command: String) -> Dictionary:
+	var normalized := raw_command.strip_edges().replace(" ", "")
+	if normalized.is_empty():
+		return _error("Empty calculator command")
+
+	# One function per command, comma-separated: operation,a,b
+	# Supported operations: mul/div or x/: aliases
+	var parts := normalized.split(",", false)
+	if parts.size() != 3:
+		return _error("Use format: operation,a,b (example: mul,6,7)")
+
+	var operation := _normalize_operation(parts[0])
+	if operation.is_empty():
+		return _error("Unknown operation '%s'. Use mul/div (or x/:)." % parts[0])
+
+	if not _is_number(parts[1]) or not _is_number(parts[2]):
+		return _error("Arguments must be numbers")
+
+	var a := float(parts[1])
+	var b := float(parts[2])
+
+	if operation == COMMAND_DIVIDE and is_zero_approx(b):
+		return _error("Division by zero")
+
+	var result := a * b if operation == COMMAND_MULTIPLY else a / b
+	return {
+		"ok": true,
+		"operation": operation,
+		"a": a,
+		"b": b,
+		"result": result
+	}
+
+func _normalize_operation(operation: String) -> String:
+	var op := operation.to_lower()
+	match op:
+		"mul", "x", "*":
+			return COMMAND_MULTIPLY
+		"div", ":", "/":
+			return COMMAND_DIVIDE
+		_:
+			return ""
+
+func _is_number(text: String) -> bool:
+	return text.is_valid_float() or text.is_valid_int()
+
+func _error(message: String) -> Dictionary:
+	return {
+		"ok": false,
+		"error": message
+	}

--- a/scripts/universal_console_controller.gd
+++ b/scripts/universal_console_controller.gd
@@ -26,6 +26,7 @@ var command_history: Array[String] = []
 var history_index: int = -1
 var output_lines: Array[String] = []
 var console_commands: Dictionary = {}
+var dream_calculator := DreamCalculator.new()
 
 # Animation State
 var prompt_pulse_timer: float = 0.0
@@ -78,6 +79,7 @@ func register_console_commands() -> void:
 		"pentagon": "Pentagon of Creation commands",
 		"consciousness": "Consciousness level commands",
 		"timers": "Universal Timers System commands",
+		"calc": "Run dumb calculator (format: calc mul,6,7 or calc div,20,5)",
 		"turns": "Turn-based collaboration commands",
 		"genesis": "Biblical genesis pattern commands",
 		"cosmic": "Cosmic insight commands",
@@ -365,6 +367,8 @@ func process_command(command: String) -> void:
 			harmony_command(args)
 		"timers":
 			timers_command(args)
+		"calc":
+			calculator_command(args)
 		"turns":
 			turns_command(args)
 		"exit":
@@ -373,6 +377,29 @@ func process_command(command: String) -> void:
 			print_to_console("❌ Unknown command: " + cmd + " (type 'help' for commands)", "error")
 	
 	is_processing_command = false
+
+func calculator_command(args: Array) -> void:
+	"""Simple calculator: one function per command using comma separators."""
+	if args.is_empty():
+		print_to_console("🧮 Usage: calc mul,6,7 (or calc div,20,5)", "system")
+		return
+
+	var calculator_input := " ".join(args)
+	var result := dream_calculator.evaluate(calculator_input)
+	if not result.get("ok", false):
+		print_to_console("❌ %s" % result.get("error", "Unknown calculator error"), "error")
+		return
+
+	var symbol := "×" if result.operation == DreamCalculator.COMMAND_MULTIPLY else "÷"
+	print_to_console(
+		"🧮 %s %s %s = %s" % [
+			str(result.a),
+			symbol,
+			str(result.b),
+			str(result.result)
+		],
+		"ai"
+	)
 
 func show_help() -> void:
 	"""Show available commands"""


### PR DESCRIPTION
### Motivation
- Provide a simple, deterministic calculator accessible from the in-game console to support the dream/time branching design discussions and allow quick math-driven rule commands.
- Keep the calculator intentionally minimal and safe for IDE/engine use by restricting it to one operation per command and returning structured results for engine consumption.

### Description
- Added a new `DreamCalculator` utility at `scripts/dream_calculator.gd` that parses comma-separated `operation,a,b` input and supports multiply/divide with aliases (`mul/x/*` and `div/:/`).
- The calculator validates inputs and returns structured dictionaries with clear error messages for empty input, malformed payloads, non-numeric args, unknown operators, and division by zero via `DreamCalculator.evaluate()`.
- Integrated the calculator into `UniversalConsoleController` by creating `dream_calculator := DreamCalculator.new()`, registering a `calc` console command in `register_console_commands()`, and wiring `process_command()` to call a new `calculator_command(args)` handler.
- `calculator_command(args)` prints usage hints when no arguments are provided and displays formatted results using `×` or `÷` symbols when successful.

### Testing
- Attempted to run the project test suite with `godot --headless --script tests/run_tests.gd` as specified in `AGENTS.md`. This automated test run failed because the `godot` binary is not installed in the execution environment (`bash: command not found: godot`).
- No other automated test framework was available in this environment, but the changes were committed and basic file-level validation (`git diff`, file listing, and local code inspection) was performed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3d6ff2e48332ba4e5a23beff85df)